### PR TITLE
Configure Jackson date formatting.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ repositories {
 
 dependencies {
     compile("no.fint:fint-okonomi-model-java:${apiVersion}")
-    compile('no.fint:fint-utdanning-resource-model-java:3.1.0')
+    compile('no.fint:fint-utdanning-resource-model-java:3.4.0')
     compile('no.fint:fint-oauth-token-service:1.4.0')
     compile('no.fint:fint-betaling-model:1.0.0-alpha-10')
 
@@ -47,6 +47,7 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-data-mongodb:${springBootVersion}")
     compile('org.springframework.plugin:spring-plugin-core')
     compile('com.fasterxml.jackson.core:jackson-databind')
+    compile('com.fasterxml.jackson.datatype:jackson-datatype-jsr310')
     compile("com.github.springfox.loader:springfox-loader:${springfoxLoaderVersion}")
     compileOnly("org.projectlombok:lombok:${lombokVersion}")
 

--- a/src/main/java/no/fint/betaling/config/Config.java
+++ b/src/main/java/no/fint/betaling/config/Config.java
@@ -2,7 +2,10 @@ package no.fint.betaling.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import no.fint.oauth.OAuthConfig;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,6 +35,8 @@ public class Config {
 
     @PostConstruct
     public void init() {
+        objectMapper.registerModule(new JavaTimeModule());
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        objectMapper.setDateFormat(new ISO8601DateFormat());
     }
 }


### PR DESCRIPTION
LocalDate by default is configured in a not-so-pretty fashion.  With this config the expected ISO8601 date format is used instead.

Before:
```json
"createdDate":{"year":2019,"month":"NOVEMBER","era":"CE","dayOfYear":331,"dayOfWeek":"WEDNESDAY","leapYear":false,"dayOfMonth":27,"monthValue":11,"chronology":{"calendarType":"iso8601","id":"ISO"}}
```

After:
```json
"createdDate":"2019-11-27"
```