### PR TITLE
Update strategy for determining amount due.

### DIFF
--- a/src/main/java/no/fint/betaling/service/ClaimService.java
+++ b/src/main/java/no/fint/betaling/service/ClaimService.java
@@ -184,7 +184,7 @@ public class ClaimService {
         fakturaList.stream()
                 .map(FakturaResource::getRestbelop)
                 .filter(Objects::nonNull)
-                .findFirst()
+                .reduce(Long::sum)
                 .ifPresent(updater.acceptPartially(AMOUNT_DUE));
 
         boolean credited = fakturaList.stream().allMatch(FakturaResource::getKreditert);


### PR DESCRIPTION
Determine amount due from `Faktura.restbelop` instead.

Fixes #55 